### PR TITLE
JobCancellationToken - Fix Issue #19

### DIFF
--- a/src/Hangfire.LiteDB/LiteDbConnection.cs
+++ b/src/Hangfire.LiteDB/LiteDbConnection.cs
@@ -197,7 +197,7 @@ namespace Hangfire.LiteDB
                 .Select(x => x.StateHistory)
                 .FirstOrDefault();
 
-            var state = latest?[0];
+            var state = latest?.Last();
 
             if (state == null)
                 return null;

--- a/src/Hangfire.LiteDB/LiteDbConnection.cs
+++ b/src/Hangfire.LiteDB/LiteDbConnection.cs
@@ -197,7 +197,7 @@ namespace Hangfire.LiteDB
                 .Select(x => x.StateHistory)
                 .FirstOrDefault();
 
-            var state = latest?.Last();
+            var state = latest?.LastOrDefault();
 
             if (state == null)
                 return null;


### PR DESCRIPTION
Fix Issue #19 

**Technical Detail**

The state always returned by the job in the GetStateData method, was enqueue, this because the first element of the StateHistory array is returned.

Hangfire executes CancellationToken when the Job has a different status than Processing.

![image](https://user-images.githubusercontent.com/1153361/68049526-83afda00-fcb9-11e9-81d4-2b1dba65cfe2.png)

![image](https://user-images.githubusercontent.com/1153361/68049549-94f8e680-fcb9-11e9-9ca7-697ee349c5bc.png)


**Testing**

![Screenshot_2  2](https://user-images.githubusercontent.com/1153361/68049084-662e4080-fcb8-11e9-99bd-9dc5fd7f1e87.png)

![Screenshot_4  2](https://user-images.githubusercontent.com/1153361/68049088-69293100-fcb8-11e9-8035-cbb88137bfa6.png)

![Screenshot_5  2](https://user-images.githubusercontent.com/1153361/68049097-6dede500-fcb8-11e9-8d7e-e134abf07678.png)

![Screenshot_6  2](https://user-images.githubusercontent.com/1153361/68049109-721a0280-fcb8-11e9-82bb-0405c3538dcd.png)

![Screenshot_1  2](https://user-images.githubusercontent.com/1153361/68049120-7d6d2e00-fcb8-11e9-81c3-953c648bbcba.png)

**Important Note**
![image](https://user-images.githubusercontent.com/1153361/68049289-e81e6980-fcb8-11e9-8101-75d93c01fd8d.png)

Although this change resolves the problem with **CancellationToken**, for some reason the Hangfire stops if a Job takes too long to execute (I guess it is because of the blocking of the LiteDb file).

Do not pass this change, until we can solve this problem.