### PR TITLE
Fix memory leak caused by Query API, replace those with lambda expressions

### DIFF
--- a/src/Hangfire.LiteDB/LiteDbJobQueue.cs
+++ b/src/Hangfire.LiteDB/LiteDbJobQueue.cs
@@ -3,21 +3,17 @@ using System.Threading;
 using Hangfire.Annotations;
 using Hangfire.LiteDB.Entities;
 using Hangfire.Storage;
-using LiteDB;
 
 namespace Hangfire.LiteDB
 {
     /// <summary>
-    /// 
     /// </summary>
     public class LiteDbJobQueue : IPersistentJobQueue
     {
+        private readonly HangfireDbContext _connection;
         private readonly LiteDbStorageOptions _storageOptions;
 
-        private readonly HangfireDbContext _connection;
-
         /// <summary>
-        /// 
         /// </summary>
         /// <param name="connection"></param>
         /// <param name="storageOptions"></param>
@@ -28,7 +24,6 @@ namespace Hangfire.LiteDB
         }
 
         /// <summary>
-        /// 
         /// </summary>
         /// <param name="queues"></param>
         /// <param name="cancellationToken"></param>
@@ -36,36 +31,23 @@ namespace Hangfire.LiteDB
         [NotNull]
         public IFetchedJob Dequeue(string[] queues, CancellationToken cancellationToken)
         {
-            if (queues == null)
-            {
-                throw new ArgumentNullException(nameof(queues));
-            }
+            if (queues == null) throw new ArgumentNullException(nameof(queues));
 
-            if (queues.Length == 0)
-            {
-                throw new ArgumentException("Queue array must be non-empty.", nameof(queues));
-            }
-
-            var fetchConditions = new[]
-            {
-                Query.EQ("FetchedAt", null),
-                Query.LT("FetchedAt", DateTime.UtcNow.AddSeconds(_storageOptions.InvisibilityTimeout.Negate().TotalSeconds))
-            };
-            var fetchConditionsIndex = 0;
+            if (queues.Length == 0) throw new ArgumentException("Queue array must be non-empty.", nameof(queues));
 
             JobQueue fetchedJob = null;
             while (fetchedJob == null)
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                var fetchCondition = fetchConditions[fetchConditionsIndex];
 
                 foreach (var queue in queues)
                 {
                     var lockQueue = string.Intern($"f13333e1-a0c8-48c8-bf8c-788e89030329_{queue}");
                     lock (lockQueue)
                     {
-                        fetchedJob = _connection.JobQueue.FindOne(Query.And(fetchCondition, Query.EQ("Queue", queue)));
+                        fetchedJob =
+                            _connection.JobQueue.FindOne(x => x.FetchedAt == null && x.Queue == queue);
 
                         if (fetchedJob != null)
                         {
@@ -76,22 +58,40 @@ namespace Hangfire.LiteDB
                     }
                 }
 
-                if (fetchedJob == null && fetchConditionsIndex == fetchConditions.Length - 1)
+                if (fetchedJob == null)
+                    foreach (var queue in queues)
+                    {
+                        var lockQueue = string.Intern($"f13333e1-a0c8-48c8-bf8c-788e89030329_{queue}");
+                        lock (lockQueue)
+                        {
+                            fetchedJob =
+                                _connection.JobQueue.FindOne(x =>
+                                    x.FetchedAt <
+                                    DateTime.UtcNow.AddSeconds(
+                                        _storageOptions.InvisibilityTimeout.Negate().TotalSeconds) && x.Queue == queue);
+
+                            if (fetchedJob != null)
+                            {
+                                fetchedJob.FetchedAt = DateTime.UtcNow;
+                                _connection.JobQueue.Update(fetchedJob);
+                                break;
+                            }
+                        }
+                    }
+
+                if (fetchedJob == null)
                 {
                     // ...and we are out of fetch conditions as well.
                     // Wait for a while before polling again.
                     cancellationToken.WaitHandle.WaitOne(_storageOptions.QueuePollInterval);
                     cancellationToken.ThrowIfCancellationRequested();
                 }
-
-                // Move on to next fetch condition
-                fetchConditionsIndex = (fetchConditionsIndex + 1) % fetchConditions.Length;
             }
 
             return new LiteDbFetchedJob(_connection, fetchedJob.Id, fetchedJob.JobId, fetchedJob.Queue);
         }
+
         /// <summary>
-        /// 
         /// </summary>
         /// <param name="queue"></param>
         /// <param name="jobId"></param>

--- a/src/Hangfire.LiteDB/LiteDbJobQueue.cs
+++ b/src/Hangfire.LiteDB/LiteDbJobQueue.cs
@@ -3,17 +3,21 @@ using System.Threading;
 using Hangfire.Annotations;
 using Hangfire.LiteDB.Entities;
 using Hangfire.Storage;
+using LiteDB;
 
 namespace Hangfire.LiteDB
 {
     /// <summary>
+    /// 
     /// </summary>
     public class LiteDbJobQueue : IPersistentJobQueue
     {
-        private readonly HangfireDbContext _connection;
         private readonly LiteDbStorageOptions _storageOptions;
 
+        private readonly HangfireDbContext _connection;
+
         /// <summary>
+        /// 
         /// </summary>
         /// <param name="connection"></param>
         /// <param name="storageOptions"></param>
@@ -24,6 +28,7 @@ namespace Hangfire.LiteDB
         }
 
         /// <summary>
+        /// 
         /// </summary>
         /// <param name="queues"></param>
         /// <param name="cancellationToken"></param>
@@ -31,23 +36,36 @@ namespace Hangfire.LiteDB
         [NotNull]
         public IFetchedJob Dequeue(string[] queues, CancellationToken cancellationToken)
         {
-            if (queues == null) throw new ArgumentNullException(nameof(queues));
+            if (queues == null)
+            {
+                throw new ArgumentNullException(nameof(queues));
+            }
 
-            if (queues.Length == 0) throw new ArgumentException("Queue array must be non-empty.", nameof(queues));
+            if (queues.Length == 0)
+            {
+                throw new ArgumentException("Queue array must be non-empty.", nameof(queues));
+            }
+
+            var fetchConditions = new[]
+            {
+                Query.EQ("FetchedAt", null),
+                Query.LT("FetchedAt", DateTime.UtcNow.AddSeconds(_storageOptions.InvisibilityTimeout.Negate().TotalSeconds))
+            };
+            var fetchConditionsIndex = 0;
 
             JobQueue fetchedJob = null;
             while (fetchedJob == null)
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
+                var fetchCondition = fetchConditions[fetchConditionsIndex];
 
                 foreach (var queue in queues)
                 {
                     var lockQueue = string.Intern($"f13333e1-a0c8-48c8-bf8c-788e89030329_{queue}");
                     lock (lockQueue)
                     {
-                        fetchedJob =
-                            _connection.JobQueue.FindOne(x => x.FetchedAt == null && x.Queue == queue);
+                        fetchedJob = _connection.JobQueue.FindOne(Query.And(fetchCondition, Query.EQ("Queue", queue)));
 
                         if (fetchedJob != null)
                         {
@@ -58,40 +76,22 @@ namespace Hangfire.LiteDB
                     }
                 }
 
-                if (fetchedJob == null)
-                    foreach (var queue in queues)
-                    {
-                        var lockQueue = string.Intern($"f13333e1-a0c8-48c8-bf8c-788e89030329_{queue}");
-                        lock (lockQueue)
-                        {
-                            fetchedJob =
-                                _connection.JobQueue.FindOne(x =>
-                                    x.FetchedAt <
-                                    DateTime.UtcNow.AddSeconds(
-                                        _storageOptions.InvisibilityTimeout.Negate().TotalSeconds) && x.Queue == queue);
-
-                            if (fetchedJob != null)
-                            {
-                                fetchedJob.FetchedAt = DateTime.UtcNow;
-                                _connection.JobQueue.Update(fetchedJob);
-                                break;
-                            }
-                        }
-                    }
-
-                if (fetchedJob == null)
+                if (fetchedJob == null && fetchConditionsIndex == fetchConditions.Length - 1)
                 {
                     // ...and we are out of fetch conditions as well.
                     // Wait for a while before polling again.
                     cancellationToken.WaitHandle.WaitOne(_storageOptions.QueuePollInterval);
                     cancellationToken.ThrowIfCancellationRequested();
                 }
+
+                // Move on to next fetch condition
+                fetchConditionsIndex = (fetchConditionsIndex + 1) % fetchConditions.Length;
             }
 
             return new LiteDbFetchedJob(_connection, fetchedJob.Id, fetchedJob.JobId, fetchedJob.Queue);
         }
-
         /// <summary>
+        /// 
         /// </summary>
         /// <param name="queue"></param>
         /// <param name="jobId"></param>


### PR DESCRIPTION
Hello!

I have recently opened an issue about the memory leak #28 I potentially (back then, now for sure) found in one of the files in this Hangfire connector for LiteDB. 

I have performed two memory profiling sessions about 1.5 hours long each with the original code from this repo and a changed code I made in my fork. The results indicate that the reason for leak is confirmed and its Query.EQ, Query.LT and other bson expression building API calls which resulted in indefinite growth of ConcurrentDictionary<String, BsonExpressionScalarDelegate>. The probability of need to give GC more time was eliminated by running application using the Hangfire and this connector for around 72h with the same results. Unfortunately, I do not have screenshots with those results, but it's easy to reproduce if you are willing to check. Following results were acquired at almost parallel run of 2 builds on the same machine.
  
1. Here are the results of the run acquired for the original code of the latest release from this repository:
- The snapshots every 5 minutes indicate steady memory growth with no fluctuations back

![old_1-10snap](https://user-images.githubusercontent.com/35699225/133069272-27deddc1-c1e8-4148-9e14-e6c385ec6491.png)
![old_11-20snap](https://user-images.githubusercontent.com/35699225/133069282-1d2b2a5f-7932-4da0-bd76-52f793db891b.png)

- Comparison of dominating memory consumers between snapshot n.2 and snapshot n.20 show the key objects which have grown
![old_dominators_snap2](https://user-images.githubusercontent.com/35699225/133069636-07344142-2644-42e6-9c57-665ee8361a81.png)
![old_dominators_20snap](https://user-images.githubusercontent.com/35699225/133069641-feefd645-9f2d-42ae-91f2-de192b11670d.png)

1. Here are the results of profiling the build I made from code with changes in this PR

- The snapshots every 5 minutes indicate stable memory consumption cycles with fluctuations up and down results in average same amount of memory used

![new_1-10snap](https://user-images.githubusercontent.com/35699225/133070154-01b6c078-7adf-4da7-91ef-49ab8955aea7.png)
![new_11-20snap](https://user-images.githubusercontent.com/35699225/133070165-ad38b83b-b7f9-4a73-b73a-cc907e464226.png)

- Comparison of dominating memory consumers between snapshot n.2 and snapshot n.20 show almost no difference
![new_dominators_2snap](https://user-images.githubusercontent.com/35699225/133070217-24fb4ba7-2fba-47d4-ab6a-2ce318b56ef4.png)
![new_dominators_20snap](https://user-images.githubusercontent.com/35699225/133070231-ced32a2f-3d7e-4960-9852-48113cf49772.png)

The test was performed with ConsoleSample project of this repo with jobs recurrent period of 15 sec instead of a minute and 2 similar jobs added.
`public static class Program
    {
        public static int X;
        public static int Y;
        public static int Z;

        public static void Main()
        {
            // you can use LiteDB Storage and specify the connection string name
            GlobalConfiguration.Configuration
                .UseColouredConsoleLogProvider()
                .LiteDbStorage("Hangfire.db");

            //you have to create an instance of background job server at least once for background jobs to run
            using (new BackgroundJobServer())
            {
                // Run once
                BackgroundJob.Enqueue(() => Console.WriteLine("Background Job: Hello, world!"));

                BackgroundJob.Enqueue(() => Test());

                for (var i = 0; i < 15; i++)
                {
                    // Run every 15 seconds
                    RecurringJob.AddOrUpdate(() => Test(), "*/15 * * * * *");
                    RecurringJob.AddOrUpdate(() => Test1(), "*/15 * * * * *");
                    RecurringJob.AddOrUpdate(() => Test2(), "*/15 * * * * *");
                }

                Console.WriteLine("Press Enter to exit...");
                Console.ReadLine();
            }
        }

        [AutomaticRetry(Attempts = 0, LogEvents = true)]
        public static void Test()
        {
            Console.WriteLine($"{X++} Cron Job: Hello, world!");
            //throw new ArgumentException("fail");
        }

        [AutomaticRetry(Attempts = 0, LogEvents = true)]
        public static void Test1()
        {
            Console.WriteLine($"{Y++} Cron Job 1: Hello, world! " + Math.Pow(Y, 2));
            //throw new ArgumentException("fail");
        }

        [AutomaticRetry(Attempts = 0, LogEvents = true)]
        public static void Test2()
        {
            Console.WriteLine($"{Z++} Cron Job 2: Hello, world!" + Math.Pow(Y, 3));
            //throw new ArgumentException("fail");
        }
    }`

If presented proof is not sufficient, you can test the fix yourself and reconfirm. @codeyu it would be great to get this PR merged in a close time. I believe there are many people like me and my team who have their applications deployed and running for indefinite amount of time without supposed interruption, and in this scenario memory leak can grow to gigabytes in a year, which is not affordable in our case.

I am gonna use my fork for now, but I would appreciate the solution to be in original library.

Thank you in advance!

Daniil Zhitnitskii 




